### PR TITLE
Dev

### DIFF
--- a/lib/chroma-docker-image-ecr-deployment-cdk-stack.ts
+++ b/lib/chroma-docker-image-ecr-deployment-cdk-stack.ts
@@ -11,6 +11,7 @@ export class ChromaDockerImageEcrDeploymentCdkStack extends cdk.Stack {
     const ecrRepository = new ecr.Repository(this, `${props.appName}-${props.environment}-DockerImageEcrRepository`, {
       repositoryName: props.repositoryName,
       removalPolicy: cdk.RemovalPolicy.DESTROY,
+      autoDeleteImages: true,
       encryption: ecr.RepositoryEncryption.AES_256
     });
 

--- a/lib/chroma-docker-image-ecr-kms-deployment-cdk-stack.ts
+++ b/lib/chroma-docker-image-ecr-kms-deployment-cdk-stack.ts
@@ -18,6 +18,7 @@ export class ChromaDockerImageEcrDeploymentCdkStack extends cdk.Stack {
         const ecrRepository = new ecr.Repository(this, `${props.appName}-${props.environment}-DockerImageEcrRepository`, {
             repositoryName: props.repositoryName,
             removalPolicy: cdk.RemovalPolicy.DESTROY,
+            autoDeleteImages: true,
             encryption: ecr.RepositoryEncryption.KMS,
             encryptionKey: kmsKey,
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "chroma-docker-image-ecr-deployment-cdk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroma-docker-image-ecr-deployment-cdk",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "aws-cdk-lib": "2.113.0",
-        "cdk-ecr-deployment": "^2.5.37",
+        "cdk-ecr-deployment": "^2.5.38",
         "constructs": "^10.3.0",
         "dotenv": "^16.3.1",
         "source-map-support": "^0.5.21"
@@ -1897,9 +1897,9 @@
       ]
     },
     "node_modules/cdk-ecr-deployment": {
-      "version": "2.5.37",
-      "resolved": "https://registry.npmjs.org/cdk-ecr-deployment/-/cdk-ecr-deployment-2.5.37.tgz",
-      "integrity": "sha512-PARACtsEszYn46Jdv5RcLBeetnS4pind29JUVuzHkVoDFpfEy4x6oJQHmslkxfotwoJ8GhWGcABS/i9671W7Pg==",
+      "version": "2.5.38",
+      "resolved": "https://registry.npmjs.org/cdk-ecr-deployment/-/cdk-ecr-deployment-2.5.38.tgz",
+      "integrity": "sha512-qZBr1SOEaHJOHEb/bKDm6caUCDCBkGlFZjcHAOoXDiV+Cl4jMgzTcVX4M+nze4yO8RCsdOCl8ZbiYK6CjP8qzQ==",
       "bundleDependencies": [
         "got",
         "hpagent"
@@ -1949,7 +1949,7 @@
       }
     },
     "node_modules/cdk-ecr-deployment/node_modules/@types/cacheable-request/node_modules/@types/node": {
-      "version": "20.10.1",
+      "version": "20.10.2",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1970,7 +1970,7 @@
       }
     },
     "node_modules/cdk-ecr-deployment/node_modules/@types/keyv/node_modules/@types/node": {
-      "version": "20.10.1",
+      "version": "20.10.2",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1986,7 +1986,7 @@
       }
     },
     "node_modules/cdk-ecr-deployment/node_modules/@types/responselike/node_modules/@types/node": {
-      "version": "20.10.1",
+      "version": "20.10.2",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroma-docker-image-ecr-deployment-cdk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "bin": {
     "chroma-docker-image-ecr-deployment-cdk": "bin/chroma-docker-image-ecr-deployment-cdk.js"
   },
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "2.113.0",
-    "cdk-ecr-deployment": "^2.5.37",
+    "cdk-ecr-deployment": "^2.5.38",
     "constructs": "^10.3.0",
     "dotenv": "^16.3.1",
     "source-map-support": "^0.5.21"


### PR DESCRIPTION
## type:
enhancement

___
## description:
This PR introduces two main changes:
- The auto-deletion of images is enabled in the ECR repositories, which will automatically delete untagged images.
- The core libraries have been updated, including an update to the 'cdk-ecr-deployment' library from version 2.5.37 to 2.5.38.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `lib/chroma-docker-image-ecr-deployment-cdk-stack.ts`: Added the 'autoDeleteImages' property to the ECR repository configuration, setting it to true. This will enable automatic deletion of untagged images.
- `lib/chroma-docker-image-ecr-kms-deployment-cdk-stack.ts`: Similar to the previous file, the 'autoDeleteImages' property has been added to the ECR repository configuration, enabling automatic deletion of untagged images.
- `package-lock.json`: The 'cdk-ecr-deployment' library has been updated from version 2.5.37 to 2.5.38. Additionally, the package version has been updated from 0.1.0 to 0.2.0.
- `package.json`: The 'cdk-ecr-deployment' library has been updated from version 2.5.37 to 2.5.38. The package version has also been updated from 0.1.0 to 0.2.0.
</details>
