### PR TITLE
Only check ECR_REPOSITORY_NAME and APP_NAME

### DIFF
--- a/bin/chroma-docker-image-ecr-deployment-cdk.ts
+++ b/bin/chroma-docker-image-ecr-deployment-cdk.ts
@@ -30,7 +30,7 @@ function checkEnvVariables(...args: string[]) {
 }
 
 // check if the environment variables are set
-checkEnvVariables('ECR_REPOSITORY_NAME', 'APP_NAME', 'IMAGE_VERSION');
+checkEnvVariables('ECR_REPOSITORY_NAME', 'APP_NAME');
 
 for (const cdkRegion of cdkRegions) {
     for (const environment of environments) {
@@ -42,8 +42,8 @@ for (const cdkRegion of cdkRegions) {
             tags: {
                 environment,
             },
-            repositoryName: `${process.env.ECR_REPOSITORY_NAME}-${environment}` ?? 'chromadb-docker-image-ecr-deployment-cdk',
-            appName: process.env.APP_NAME ?? 'chroma-vectordatabase',
+            repositoryName: `${process.env.ECR_REPOSITORY_NAME}-${environment}`,
+            appName: process.env.APP_NAME,
             imageVersion: process.env.IMAGE_VERSION ?? DEFAULT_IMAGE_VERSION,
             environment: environment
         });


### PR DESCRIPTION
## type:
Refactoring

___
## description:
This PR refactors the environment variables check in the `chroma-docker-image-ecr-deployment-cdk.ts` file. The main changes include:
- Removing 'IMAGE_VERSION' from the list of environment variables that are checked at the start of the script.
- Removing default values for 'ECR_REPOSITORY_NAME' and 'APP_NAME' when defining the 'repositoryName' and 'appName' respectively.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `bin/chroma-docker-image-ecr-deployment-cdk.ts`: The 'IMAGE_VERSION' variable has been removed from the initial environment variables check. Also, the default values for 'ECR_REPOSITORY_NAME' and 'APP_NAME' have been removed when defining the 'repositoryName' and 'appName' respectively.
</details>
