### PR TITLE
Dev

### DIFF
--- a/bin/chroma-docker-image-ecr-deployment-cdk.ts
+++ b/bin/chroma-docker-image-ecr-deployment-cdk.ts
@@ -4,6 +4,7 @@ import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import * as dotenv from 'dotenv';
 import { ChromaDockerImageEcrDeploymentCdkStack } from '../lib/chroma-docker-image-ecr-deployment-cdk-stack';
+import { IEnvTypes } from '../process-env-typed';
 
 dotenv.config(); // Load environment variables from .env file
 const app = new cdk.App();
@@ -32,6 +33,12 @@ function checkEnvVariables(...args: string[]) {
 // check if the environment variables are set
 checkEnvVariables('ECR_REPOSITORY_NAME', 'APP_NAME');
 
+const envTypes: IEnvTypes = {
+    ECR_REPOSITORY_NAME: process.env.ECR_REPOSITORY_NAME ?? `chromadb-docker-image-erc-repository`,
+    APP_NAME: process.env.APP_NAME ?? `chroma-vectordatabase`,
+    IMAGE_VERSION: process.env.IMAGE_VERSION ?? DEFAULT_IMAGE_VERSION,
+};
+
 for (const cdkRegion of cdkRegions) {
     for (const environment of environments) {
         new ChromaDockerImageEcrDeploymentCdkStack(app, `ChromaDockerImageEcrDeploymentCdkStack-${cdkRegion}-${environment}`, {
@@ -42,9 +49,9 @@ for (const cdkRegion of cdkRegions) {
             tags: {
                 environment,
             },
-            repositoryName: `${process.env.ECR_REPOSITORY_NAME}-${environment}`,
-            appName: process.env.APP_NAME,
-            imageVersion: process.env.IMAGE_VERSION ?? DEFAULT_IMAGE_VERSION,
+            repositoryName: `${envTypes.ECR_REPOSITORY_NAME}-${environment}`,
+            appName: envTypes.APP_NAME,
+            imageVersion: envTypes.IMAGE_VERSION ?? DEFAULT_IMAGE_VERSION,
             environment: environment
         });
     }

--- a/lib/ChromaDockerImageEcrDeploymentCdkStackProps.ts
+++ b/lib/ChromaDockerImageEcrDeploymentCdkStackProps.ts
@@ -3,6 +3,6 @@ import * as cdk from 'aws-cdk-lib';
 export interface ChromaDockerImageEcrDeploymentCdkStackProps extends cdk.StackProps {
     readonly repositoryName: string;
     readonly appName: string;
-    imageVersion: string;
-    environment: string;
+    readonly imageVersion: string;
+    readonly environment: string;
 }

--- a/lib/ChromaDockerImageEcrDeploymentCdkStackProps.ts
+++ b/lib/ChromaDockerImageEcrDeploymentCdkStackProps.ts
@@ -3,6 +3,6 @@ import * as cdk from 'aws-cdk-lib';
 export interface ChromaDockerImageEcrDeploymentCdkStackProps extends cdk.StackProps {
     readonly repositoryName: string;
     readonly appName: string;
-    imageVersion?: string;
-    environment?: string;
+    imageVersion: string;
+    environment: string;
 }

--- a/process-env-typed.ts
+++ b/process-env-typed.ts
@@ -1,0 +1,5 @@
+export interface IEnvTypes {
+    ECR_REPOSITORY_NAME: string;
+    APP_NAME: string;
+    IMAGE_VERSION?: string;
+}


### PR DESCRIPTION
## type:
Refactoring

___
## description:
This PR introduces changes to the way environment variables are handled in the AWS CDK deployment script. The main changes include:
- Addition of a new TypeScript interface `IEnvTypes` to type the environment variables.
- Refactoring the code to use the new `IEnvTypes` interface when reading environment variables.
- Changing the `imageVersion` and `environment` properties in `ChromaDockerImageEcrDeploymentCdkStackProps` to be read-only.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `bin/chroma-docker-image-ecr-deployment-cdk.ts`: The environment variables are now read into a constant `envTypes` of type `IEnvTypes`. This constant is then used when creating a new `ChromaDockerImageEcrDeploymentCdkStack`.
- `lib/ChromaDockerImageEcrDeploymentCdkStackProps.ts`: The `imageVersion` and `environment` properties have been changed to be read-only.
- `process-env-typed.ts`: A new TypeScript interface `IEnvTypes` has been added to type the environment variables.
</details>
