### PR TITLE
Update type/node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.10",
-        "@types/node": "20.10.2",
+        "@types/node": "20.10.3",
         "@types/source-map-support": "^0.5.10",
         "aws-cdk": "2.113.0",
         "jest": "^29.7.0",
@@ -1184,9 +1184,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.10.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.2.tgz",
-      "integrity": "sha512-37MXfxkb0vuIlRKHNxwCkb60PNBpR94u4efQuN4JgIAm66zfCDXGSAFCef9XUWFovX2R1ok6Z7MHhtdVXXkkIw==",
+      "version": "20.10.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.3.tgz",
+      "integrity": "sha512-XJavIpZqiXID5Yxnxv3RUDKTN5b81ddNC3ecsA0SoFXz/QU8OGBwZGMomiq0zw+uuqbL/krztv/DINAQ/EV4gg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.10",
-    "@types/node": "20.10.2",
+    "@types/node": "20.10.3",
     "@types/source-map-support": "^0.5.10",
     "aws-cdk": "2.113.0",
     "jest": "^29.7.0",


### PR DESCRIPTION
## type:
enhancement

___
## description:
This PR updates the version of Node.js type definitions from 20.10.2 to 20.10.3. The changes are reflected in both package.json and package-lock.json files. This update ensures that the project is using the latest type definitions, which can include bug fixes, new features, and other improvements.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `package.json`: Updated the version of @types/node in the devDependencies section from 20.10.2 to 20.10.3.
- `package-lock.json`: Updated the version, resolved URL, and integrity hash of @types/node in the node_modules section.
</details>
