### PR TITLE
Only run pipeline to PR to dev branch only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,6 @@ on:
   pull_request:
     branches:
       - dev
-      - stg
-      - main
 
 jobs:
   deploy:


### PR DESCRIPTION
## type:
enhancement

___
## description:
This PR modifies the GitHub Actions workflow to only trigger the pipeline for pull requests made to the 'dev' branch. Previously, the pipeline was also triggered for pull requests made to the 'stg' and 'main' branches.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `.github/workflows/release.yml`: The 'pull_request' event trigger has been updated to only include the 'dev' branch. The 'stg' and 'main' branches have been removed from the trigger event.
</details>
