### PR TITLE
Fix invalid src dockerhub file

### DIFF
--- a/lib/chroma-docker-image-ecr-deployment-cdk-stack.ts
+++ b/lib/chroma-docker-image-ecr-deployment-cdk-stack.ts
@@ -21,7 +21,7 @@ export class ChromaDockerImageEcrDeploymentCdkStack extends cdk.Stack {
 
     // Copy from docker registry to ECR.
     new ecrDeploy.ECRDeployment(this, `${props.appName}-${props.environment}-DockerImageEcrDeployment`, {
-      src: new ecrDeploy.DockerImageName('qdrant/qdrant:latest'),
+      src: new ecrDeploy.DockerImageName('chromadb/chroma:latest'),
       dest: new ecrDeploy.DockerImageName(`${ecrRepository.repositoryUri}:${props.imageVersion}`),
     });
   }


### PR DESCRIPTION
## type:
bug_fix

___
## description:
This PR addresses an issue with the source Docker image used in the ECR deployment process. The source Docker image has been updated from 'qdrant/qdrant:latest' to 'chromadb/chroma:latest'. This change ensures that the correct Docker image is used for deployment.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `lib/chroma-docker-image-ecr-deployment-cdk-stack.ts`: The source Docker image in the ECR deployment process has been updated. The new source is 'chromadb/chroma:latest'.
</details>
