### PR TITLE
Fix resource naming

### DIFF
--- a/lib/chroma-docker-image-ecr-deployment-cdk-stack.ts
+++ b/lib/chroma-docker-image-ecr-deployment-cdk-stack.ts
@@ -23,7 +23,7 @@ export class ChromaDockerImageEcrDeploymentCdkStack extends cdk.Stack {
         const deployImageVersions = [props.imageVersion, LATEST_IMAGE_VERSION];
         for (const deployImageVersion of deployImageVersions) {
             // Copy from docker registry to ECR.
-            new ecrDeploy.ECRDeployment(this, `${props.appName}-${props.environment}-ECRDeployment`, {
+            new ecrDeploy.ECRDeployment(this, `${props.appName}-${props.environment}-${deployImageVersion}-ECRDeployment`, {
                 src: new ecrDeploy.DockerImageName('chromadb/chroma:latest'),
                 dest: new ecrDeploy.DockerImageName(`${ecrRepository.repositoryUri}:${deployImageVersion}`),
             });


### PR DESCRIPTION
## Type
Enhancement


___

## Description
This PR introduces a change in the naming convention of the ECR Deployment resources. Previously, the naming convention was `${props.appName}-${props.environment}-ECRDeployment`. This has been updated to `${props.appName}-${props.environment}-${deployImageVersion}-ECRDeployment`, where `deployImageVersion` is a variable representing the version of the image being deployed. This change will allow for better tracking and management of different versions of the deployed images.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>chroma-docker-image-ecr-deployment-cdk-stack.ts&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        lib/chroma-docker-image-ecr-deployment-cdk-stack.ts<br><br>
        <strong>The ECR Deployment resource naming has been updated to <br>include the version of the image being deployed. This change <br>affects the instantiation of the `ECRDeployment` class.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/AI4Organization/chroma-docker-image-ecr-deployment-cdk/pull/26/files#diff-954cbddc6e252c773fdb7d50f88f6ed622d28a71eefa4168ff92592a94991c5a"> +1/-1</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>